### PR TITLE
Allow longer messages when Jasmin SMS backend is used

### DIFF
--- a/smsgateway/__init__.py
+++ b/smsgateway/__init__.py
@@ -26,10 +26,14 @@ def send(to, msg, signature, using=None, reliable=False):
         return
 
     from smsgateway.backends import get_backend
-    from smsgateway.sms import SMSRequest
+    from smsgateway.sms import SMSRequest, JasminSMSRequest
     account_dict = get_account(using)
     backend = get_backend(account_dict['backend'])
-    sms_request = SMSRequest(to, msg, signature, reliable=reliable)
+    # jasmin backend allows longer messages so it uses a subclass of SMSRequest to set a bigger max_length
+    if account_dict['backend'] == 'jasmin':
+        sms_request = JasminSMSRequest(to, msg, signature, reliable=reliable)
+    else:
+        sms_request = SMSRequest(to, msg, signature, reliable=reliable)
     return backend.send(sms_request, account_dict)
 
 

--- a/smsgateway/backends/jasmin.py
+++ b/smsgateway/backends/jasmin.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from urllib2 import urlopen
 from django.http import HttpResponse
 from django.utils.http import urlencode
 
@@ -7,9 +8,65 @@ from smsgateway import get_account, send, send_queued
 from smsgateway.models import SMS
 from smsgateway.backends.base import SMSBackend
 from smsgateway.utils import check_cell_phone_number
+from smsgateway.sms import JasminSMSRequest
+
+from smsgateway.enums import DIRECTION_OUTBOUND
 
 
 class JasminBackend(SMSBackend):
+
+    def send(self, sms_request, account_dict):
+        """
+        Send an SMS message to one or more recipients, and create entries in the
+        SMS table for each successful attempt.
+        """
+        capacity = self.get_url_capacity()
+        sender = u'[{}]'.format(self.get_slug()) if not sms_request.signature else sms_request.signature
+        reference = self.get_send_reference(sms_request)
+        all_succeeded = True
+
+        # Split SMSes into batches depending on the capacity
+        requests = []
+        while len(sms_request.to) > 0:
+            requests.append(JasminSMSRequest(
+                sms_request.to[:capacity],
+                sms_request.msg,
+                sms_request.signature,
+                reliable=sms_request.reliable,
+                reference=reference
+            ))
+            del sms_request.to[:capacity]
+
+        # Send each batch
+        for request in requests:
+            url = self.get_send_url(request, account_dict)
+
+            # Make request to provider
+            result = u''
+            if url is not None:
+                try:
+                    sock = urlopen(url)
+                    result = sock.read()
+                    sock.close()
+                except:
+                    return False
+
+            # Validate result, create log entry if successful
+            if not self.validate_send_result(result):
+                all_succeeded = False
+            else:
+                for dest in request.to:
+                    SMS.objects.create(
+                        sender=sender,
+                        content=sms_request.msg,
+                        to=dest,
+                        backend=self.get_slug(),
+                        direction=DIRECTION_OUTBOUND,
+                        gateway_ref=self.get_gateway_ref(reference, result)
+                    )
+
+        return all_succeeded
+
     def get_send_url(self, sms_request, account_dict):
         # Encode message
         msg = sms_request.msg

--- a/smsgateway/sms.py
+++ b/smsgateway/sms.py
@@ -16,3 +16,13 @@ class SMSRequest(object):
         self.signature = signature[:16] if signature[1:].isdigit() else signature[:11]
         self.reliable = reliable
         self.reference = reference
+
+
+class JasminSMSRequest(SMSRequest):
+    def __init__(self, to, msg, signature, reliable=False, reference=None):
+        """
+        The Jasmin backend can handle longer messages so we send truncate_sms a bigger max_length here
+        """
+
+        super(JasminSMSRequest, self).__init__(to, '', signature, reliable, reference)
+        self.msg = truncate_sms(msg, 500)

--- a/smsgateway/templates/smsgateway/backend_debug.html
+++ b/smsgateway/templates/smsgateway/backend_debug.html
@@ -3,8 +3,7 @@
         <title>SMSGateway Backend Tester</title>
     </head>
     <body>
-        <h1>SMSGateway Backend Tester</h1>
-
+        <h1>SMSGateway Backend Tester </h1>
         {% if message %}
         <p>{{ message }}</p>
         {% endif %}


### PR DESCRIPTION
The Jasmin SMS backend can handle longer messages (700+ characters) . This change allows messages of up to 500 characters to be sent when this backend is used.