### PR TITLE
Refactor urls.py to make django 1.10+ compatible

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -14,3 +14,6 @@ pytz>=2016.7
 django-db-locking>=2.0.0
 
 phonenumberslite==7.3.2
+
+six==1.11.0
+future==0.16.0

--- a/smsgateway/backends/base.py
+++ b/smsgateway/backends/base.py
@@ -1,4 +1,4 @@
-from urllib2 import urlopen
+from six.moves.urllib.request import urlopen
 from logging import getLogger
 from datetime import datetime
 from re import sub

--- a/smsgateway/backends/jasmin.py
+++ b/smsgateway/backends/jasmin.py
@@ -1,8 +1,11 @@
-from datetime import datetime
+# -*- coding: utf-8 -*-
 
-from urllib2 import urlopen
+from datetime import datetime
+from logging import getLogger
+
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.parse import urlencode
 from django.http import HttpResponse
-from django.utils.http import urlencode
 
 from smsgateway import get_account, send, send_queued
 from smsgateway.models import SMS
@@ -11,6 +14,8 @@ from smsgateway.utils import check_cell_phone_number
 from smsgateway.sms import SMSRequest
 
 from smsgateway.enums import DIRECTION_OUTBOUND
+
+logger = getLogger(__name__)
 
 
 class JasminBackend(SMSBackend):
@@ -42,11 +47,11 @@ class JasminBackend(SMSBackend):
             url = self.get_send_url(request, account_dict)
 
             # Make request to provider
-            result = u''
+            result = ''
             if url is not None:
                 try:
                     sock = urlopen(url)
-                    result = sock.read()
+                    result = sock.read().decode('utf_8')
                     sock.close()
                 except:
                     return False
@@ -70,10 +75,11 @@ class JasminBackend(SMSBackend):
     def get_send_url(self, sms_request, account_dict):
         # Encode message
         msg = sms_request.msg
+
         try:
             msg = msg.encode('latin-1')
-        except:
-            pass
+        except UnicodeEncodeError as e:
+            logger.warning('Error encoding message: {}'.format(e))
 
         querystring = urlencode({
             'username': account_dict['username'],

--- a/smsgateway/backends/spryng.py
+++ b/smsgateway/backends/spryng.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from builtins import chr
+from past.builtins import basestring
+
 from django.http import HttpResponse
 from django.utils.http import urlencode
 from django.conf import settings
@@ -10,7 +13,7 @@ class SpryngBackend(SMSBackend):
     def get_send_url(self, sms_request, account_dict):
         # Encode message
         msg = sms_request.msg
-        msg = msg.replace(u'€', unichr(128))
+        msg = msg.replace(u'€', chr(128))
         try:
             msg = msg.encode('iso-8859-15')
         except:

--- a/smsgateway/sms.py
+++ b/smsgateway/sms.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+
 from smsgateway.utils import check_cell_phone_number, truncate_sms
 
 
@@ -9,7 +11,7 @@ class SMSRequest(object):
         supported character set depends on the SMS gateway provider and phone model.
         The validity of the 'signature' depends on the SMS gateway provider you are using.
 
-        >>> sms_request = SMSRequest(to='+32472123456;+3298723456', u'Hello, world!', signature='9898')
+        sms_request = SMSRequest(to='+32472123456;+3298723456', u'Hello, world!', signature='9898')
         """
         self.to = [check_cell_phone_number(n) for n in (to.split(';') if isinstance(to, basestring) else to)]
         self.msg = truncate_sms(msg)

--- a/smsgateway/urls.py
+++ b/smsgateway/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from smsgateway.views import backend_debug, backend_handle_incoming
 
-urlpatterns = patterns('',
-                       url(r'^backend/debug/$', backend_debug, name='smsgateway_backend_debug'),
-                       url(r'^(?P<backend_name>.+)/incoming/$', backend_handle_incoming, name='smsgateway_backend'),
-                       )
+urlpatterns = [
+    url(r'^backend/debug/$', backend_debug, name='smsgateway_backend_debug'),
+    url(r'^(?P<backend_name>.+)/incoming/$', backend_handle_incoming, name='smsgateway_backend'),
+]

--- a/smsgateway/views.py
+++ b/smsgateway/views.py
@@ -1,8 +1,7 @@
 from django import forms
 from django.http import Http404
 from django.conf import settings
-from django.shortcuts import render_to_response
-from django.template.context import RequestContext
+from django.shortcuts import render
 from django.contrib.admin.views.decorators import staff_member_required
 
 from smsgateway import send, __version__
@@ -46,11 +45,7 @@ def backend_debug(request):
         'form': form,
         'version': __version__,
     })
-    return render_to_response(
-        'smsgateway/backend_debug.html',
-        context,
-        context_instance=RequestContext(request)
-    )
+    return render(request, 'smsgateway/backend_debug.html', context)
 
 
 def backend_handle_incoming(request, backend_name):


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/releases/1.10/

> Features removed in 1.10

> django.conf.urls.patterns() is removed.