### PR TITLE
Replace NoArgsCommand with BaseCommand

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.9.7
+Django==1.11.5
 
 django-statsd-unleashed>=1.0.1
 statsd>=2.1.2

--- a/smsgateway/management/commands/recv_smses.py
+++ b/smsgateway/management/commands/recv_smses.py
@@ -1,19 +1,18 @@
 from __future__ import absolute_import
-from django.core.management.base import NoArgsCommand
-from optparse import make_option
+from django.core.management.base import BaseCommand
 from smsgateway.tasks import recv_smses
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Receive SMSes from the Redis queue.'
-    option_list = NoArgsCommand.option_list + (
-            make_option('--backend', help='Slug of the SMS backend to read from'),
-            make_option('--async',
-                        action='store_true',
-                        dest='async',
-                        default=False,
-                        help='Process the SMSes via asynchronously via Celery')
-            )
 
-    def handle_noargs(self, **options):
+    def add_arguments(self, parser):
+            parser.add_argument('--backend', help='Slug of the SMS backend to read from'),
+            parser.add_argument('--async',
+                                action='store_true',
+                                dest='async',
+                                default=False,
+                                help='Process the SMSes via asynchronously via Celery')
+
+    def handle(self, *args, **options):
         recv_smses(options['backend'], options['async'])

--- a/smsgateway/management/commands/send_smses.py
+++ b/smsgateway/management/commands/send_smses.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 from logging import getLogger
-from optparse import make_option
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from smsgateway.tasks import _send_smses as send_smses
 
@@ -12,29 +11,28 @@ LOCK_WAIT_TIMEOUT = getattr(settings, 'SMSES_LOCK_WAIT_TIMEOUT', -1)
 logger = getLogger(__name__)
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Send SMSes in the queue. Defer the failed ones. Pass --send-deferred to retry those.'
 
-    option_list = NoArgsCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '--send-deferred',
             dest='send_deferred',
             action='store_true',
             help='Whether to send the deferred smses. Default is all non-deferred.'
         ),
-        make_option(
+        parser.add_argument(
             '--backend',
             dest='backend',
             action='store',
             help='Whether to use a certain backend.'
         ),
-        make_option(
+        parser.add_argument(
             '--limit',
             dest='limit',
             action='store',
             help='Limit the number of smses. Default is unlimited.'
         ),
-    )
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         send_smses(options['send_deferred'], options['backend'], options['limit'])


### PR DESCRIPTION
NoArgsCommand is deprecated and removed in Django 1.10