### PR TITLE
Add switch to toggle sms processing

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,3 +17,5 @@ phonenumberslite==7.3.2
 
 six>=1.11.0,<2.0
 future==0.16.0
+
+django-waffle==0.16.0

--- a/smsgateway/__init__.py
+++ b/smsgateway/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-__version__ = '2.1.19'
+__version__ = '2.1.20'
 
 
 def get_account(using=None):


### PR DESCRIPTION
In case you want to temporarily disable switch processing, we now allow
for a waffle switch to control the queue.