### PR TITLE
Use Redis for locking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,9 @@ How to install:
         'smsgateway.backends.smsextrapro.SmsExtraProBackend',
     )
 
+    # The Redis used for locking the tasks
+    SMSGATEWAY_REDIS_URL = ''
+
 * Some backends support incoming text messages:
 
     # urls.py

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,15 +3,13 @@ Django>=2.1.5
 django-statsd-unleashed>=1.0.1
 statsd>=2.1.2
 
-redis>=2.10.5
+redis>=3.0.0
 celery==4.0.2
 kombu==4.0.2
 billiard==3.5.0.2
 amqp==2.1.4
 vine==1.1.3
 pytz>=2016.7
-
-django-db-locking>=2.0.0
 
 phonenumberslite==7.3.2
 

--- a/smsgateway/__init__.py
+++ b/smsgateway/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-__version__ = '2.1.21'
+__version__ = '2.2.0'
 
 
 def get_account(using=None):


### PR DESCRIPTION
Replace django-db-locking with Redis locks. This removes a dependency on
the former, but adds one on the latter.